### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/notredamiandhrubo/ced7c635-1291-418c-940b-ea3e92afbc05/25c2e6d2-a845-46fa-9171-780953c9625f/_apis/work/boardbadge/42cb3b85-18f8-4881-bfac-2ab8765631f7)](https://dev.azure.com/notredamiandhrubo/ced7c635-1291-418c-940b-ea3e92afbc05/_boards/board/t/25c2e6d2-a845-46fa-9171-780953c9625f/Microsoft.RequirementCategory)
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/notredamiandhrubo/ced7c635-1291-418c-940b-ea3e92afbc05/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.